### PR TITLE
Add spec for building rpms.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ HELP=help/*.html
 # Use Gnu compiler
 #CC= gcc
 # Use c99 to compile according to newer ISO C standards (IEEE Std 1003.1-2001)
-CC= gcc -std=c99 -pedantic -D_XOPEN_SOURCE=600 -Wall  
+CC= gcc -std=c99 -pedantic -D_XOPEN_SOURCE=600 -Wall -fcommon
 #AUTLIBS=  -lsundials_cvode -lX11 -lm 
 #These are the 32bit compat libraries.
 #AUTLIBS= -lf2c -lsundials_cvode -lX11 -lm 

--- a/xppaut.spec
+++ b/xppaut.spec
@@ -8,8 +8,7 @@ License:        GPL
 URL:            http://www.math.pitt.edu/~bard/xpp/xpp.html
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Source0:        %{name}-%{version}.tar.gz
-Requires:       gcc
-BuildRequires:  libX11-devel
+BuildRequires:  gcc libX11-devel
 
 %define debug_package %{nil}
 

--- a/xppaut.spec
+++ b/xppaut.spec
@@ -1,0 +1,35 @@
+Name:           xppaut
+Version:        8.0
+Release:        1%{?dist}
+Summary:        X-windows Phase Plane Plus Auto
+
+Group:          Applications/Engineering
+License:        GPL
+URL:            http://www.math.pitt.edu/~bard/xpp/xpp.html
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+Source0:        %{name}-%{version}.tar.gz
+BuildRequires:  libX11-devel
+
+%define debug_package %{nil}
+
+%description
+XPPAUT is a tool for solving differential equations, difference equations, delay equations,
+functional equations, boundary value problems, and stochastic equations.
+
+%prep
+%setup -q
+%build
+make %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+rm -f ode/*.so
+make BINDIR=%{_bindir} MANDIR=%{_mandir}/man1 DESTDIR=%{buildroot} install
+%clean
+rm -rf %{buildroot}
+%files
+%defattr(-,root,root,-)
+/usr/bin/xppaut
+%doc %attr(0444,root,root) /usr/share/man/man1/xppaut.1.gz
+%doc %attr(0444,root,root) /usr/share/doc/xppaut/*
+%changelog

--- a/xppaut.spec
+++ b/xppaut.spec
@@ -8,6 +8,7 @@ License:        GPL
 URL:            http://www.math.pitt.edu/~bard/xpp/xpp.html
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Source0:        %{name}-%{version}.tar.gz
+Requires:       gcc
 BuildRequires:  libX11-devel
 
 %define debug_package %{nil}


### PR DESCRIPTION
Here is a spec file for building rpms for Red Hat type Linux distributions.  I use it in the lab machines that I manage and I provide pre-built rpms from my fedora copr here:  

https://copr.fedorainfracloud.org/coprs/leoxx/XppAut/
